### PR TITLE
refactor: replace cloudlog with slog + Promtail for log shipping

### DIFF
--- a/cmd/assistant/main.go
+++ b/cmd/assistant/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 	"telegrambot-assistant/services/config"
+	"telegrambot-assistant/services/logger"
 	"telegrambot-assistant/services/setup"
 )
 
@@ -15,10 +16,9 @@ func main() {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	loggerResources := setup.InitLogger(cfg.Loki, "telegram-assistant")
-	defer loggerResources.Sender.Close()
+	appLogger := logger.New()
 
-	bot, err := setup.InitBot(cfg.Telegram, loggerResources.Logger)
+	bot, err := setup.InitBot(cfg.Telegram, appLogger)
 	if err != nil {
 		log.Fatalf("Failed to initialize Telegram bot: %v", err)
 	}
@@ -30,7 +30,7 @@ func main() {
 
 	redisStorage := setup.InitStorage(redisClient, cfg.Redis.ExpirationTime)
 	responseStore := setup.InitResponseStore(redisStorage)
-	openAiAssistant := setup.InitAssistant(cfg.OpenAI, responseStore, loggerResources.Logger)
+	openAiAssistant := setup.InitAssistant(cfg.OpenAI, responseStore, appLogger)
 
 	go bot.HandleMessages(openAiAssistant)
 

--- a/cmd/assistant/main.go
+++ b/cmd/assistant/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
@@ -11,21 +11,25 @@ import (
 )
 
 func main() {
+	appLogger := logger.New()
+	ctx := context.Background()
+
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("Failed to load configuration: %v", err)
+		appLogger.Error(ctx, "Failed to load configuration", "error", err)
+		os.Exit(1)
 	}
-
-	appLogger := logger.New()
 
 	bot, err := setup.InitBot(cfg.Telegram, appLogger)
 	if err != nil {
-		log.Fatalf("Failed to initialize Telegram bot: %v", err)
+		appLogger.Error(ctx, "Failed to initialize Telegram bot", "error", err)
+		os.Exit(1)
 	}
 
 	redisClient, err := setup.InitRedis(cfg.Redis)
 	if err != nil {
-		log.Fatalf("Failed to initialize Redis: %v", err)
+		appLogger.Error(ctx, "Failed to initialize Redis", "error", err)
+		os.Exit(1)
 	}
 
 	redisStorage := setup.InitStorage(redisClient, cfg.Redis.ExpirationTime)
@@ -34,12 +38,11 @@ func main() {
 
 	go bot.HandleMessages(openAiAssistant)
 
-	log.Println("Assistant service started...")
+	appLogger.Info(ctx, "Assistant service started")
 
-	// Wait for termination signal
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
 	<-quit
 
-	log.Println("Shutting down assistant service...")
+	appLogger.Info(ctx, "Shutting down assistant service")
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,12 +34,14 @@ services:
     volumes:
       - ./promtail/config.yml:/etc/promtail/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock
+      - promtail_positions:/var/lib/promtail
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     depends_on:
       - app
 
 volumes:
   redis_data:
+  promtail_positions:
 
 networks:
   default:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,7 +33,7 @@ services:
       - .env
     volumes:
       - ./promtail/config.yml:/etc/promtail/config.yml:ro
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - promtail_positions:/var/lib/promtail
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,11 @@ services:
     build: .
     env_file:
       - .env
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   redis:
     container_name: redis
@@ -20,6 +25,18 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+
+  promtail:
+    container_name: promtail
+    image: grafana/promtail:3.4.2
+    env_file:
+      - .env
+    volumes:
+      - ./promtail/config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yml -config.expand-env=true
+    depends_on:
+      - app
 
 volumes:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,11 @@ services:
     image: mwazovzky/telegrambot-assistant
     env_file:
       - .env
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   redis:
     container_name: redis
@@ -20,6 +25,18 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+
+  promtail:
+    container_name: promtail
+    image: grafana/promtail:3.4.2
+    env_file:
+      - .env
+    volumes:
+      - ./promtail/config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yml -config.expand-env=true
+    depends_on:
+      - app
 
 volumes:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,12 +34,14 @@ services:
     volumes:
       - ./promtail/config.yml:/etc/promtail/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock
+      - promtail_positions:/var/lib/promtail
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     depends_on:
       - app
 
 volumes:
   redis_data:
+  promtail_positions:
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - .env
     volumes:
       - ./promtail/config.yml:/etc/promtail/config.yml:ro
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
       - promtail_positions:/var/lib/promtail
     command: -config.file=/etc/promtail/config.yml -config.expand-env=true
     depends_on:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1
 
 require (
 	github.com/caarlos0/env/v11 v11.4.0
-	github.com/mwazovzky/cloudlog v1.3.0
 	github.com/openai/openai-go v1.12.0
 	github.com/redis/go-redis/v9 v9.7.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1 h1:wG8n/XJQ07TmjbITcGiUaOtXxdrINDz1b0J1w0SzqDc=
 github.com/go-telegram-bot-api/telegram-bot-api/v5 v5.5.1/go.mod h1:A2S0CWkNylc2phvKXWBBdD3K0iGnDBGbzRpISP2zBl8=
-github.com/mwazovzky/cloudlog v1.3.0 h1:DBOEXM8W2enylu6q8ICyqIHymG/6b0V2ry5kk2B/rjw=
-github.com/mwazovzky/cloudlog v1.3.0/go.mod h1:ED2wvdL53IfYFGi+luS+LgWsSzp8XjZEOmNbbeyRRUA=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
 github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/promtail/config.yml
+++ b/promtail/config.yml
@@ -3,7 +3,7 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /var/lib/promtail/positions.yaml
 
 clients:
   - url: ${LOKI_URL}/loki/api/v1/push

--- a/promtail/config.yml
+++ b/promtail/config.yml
@@ -21,6 +21,8 @@ scrape_configs:
             values: ["app"]
     relabel_configs:
       - source_labels: [__meta_docker_container_name]
+        regex: '/(.*)'
+        replacement: '$1'
         target_label: container
       - source_labels: [__meta_docker_container_label_com_docker_compose_service]
         target_label: service

--- a/promtail/config.yml
+++ b/promtail/config.yml
@@ -1,0 +1,33 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: ${LOKI_URL}/loki/api/v1/push
+    basic_auth:
+      username: ${LOKI_USERNAME}
+      password: ${LOKI_AUTH_TOKEN}
+
+scrape_configs:
+  - job_name: telegram-assistant
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: name
+            values: ["app"]
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        target_label: container
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: service
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            msg: msg
+      - labels:
+          level:

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,9 @@ REDIS_PORT=6379
 REDIS_PASSWORD=your_redis_password
 REDIS_EXPIRATION_TIME=24h
 
+# App logging
+LOG_LEVEL=INFO  # DEBUG, INFO, WARN, ERROR (default: INFO)
+
 # Loki/Grafana (consumed by the Promtail sidecar, not the app)
 LOKI_URL=https://logs-prod-025.grafana.net
 LOKI_USERNAME=your_loki_numeric_user_id

--- a/readme.md
+++ b/readme.md
@@ -79,9 +79,9 @@ REDIS_PORT=6379
 REDIS_PASSWORD=your_redis_password
 REDIS_EXPIRATION_TIME=24h
 
-# Loki Logging
-LOKI_URL=http://localhost:3100
-LOKI_USERNAME=loki
+# Loki/Grafana (consumed by the Promtail sidecar, not the app)
+LOKI_URL=https://logs-prod-025.grafana.net
+LOKI_USERNAME=your_loki_numeric_user_id
 LOKI_AUTH_TOKEN=your_loki_token
 ```
 
@@ -121,13 +121,17 @@ After a PR is merged into `main`:
 
 ```bash
 cd /path/to/telegrambot-assistant
+git pull
 docker compose pull
 docker compose up -d --force-recreate
 docker image prune -f
 ```
 
-4. Verify the bot is running:
+4. Verify the bot and log shipper are running:
 
 ```bash
-docker compose logs -f app
+docker compose logs -f app       # structured JSON log lines
+docker compose logs -f promtail  # log shipping activity to Loki
 ```
+
+> **Note:** The `promtail` sidecar ships `app` container logs to Grafana Cloud Loki. It reads `LOKI_URL`, `LOKI_USERNAME`, and `LOKI_AUTH_TOKEN` from `.env`. The app itself writes plain JSON to stdout — no direct Loki dependency in the application code.

--- a/services/config/config.go
+++ b/services/config/config.go
@@ -10,7 +10,6 @@ type Config struct {
 	Telegram TelegramConfig
 	OpenAI   OpenAIConfig
 	Redis    RedisConfig
-	Loki     LokiConfig
 }
 
 type TelegramConfig struct {
@@ -35,12 +34,6 @@ type RedisConfig struct {
 	Port           string        `env:"REDIS_PORT,required"`
 	Password       string        `env:"REDIS_PASSWORD,required"`
 	ExpirationTime time.Duration `env:"REDIS_EXPIRATION_TIME,required"`
-}
-
-type LokiConfig struct {
-	Url      string `env:"LOKI_URL,required"`
-	Username string `env:"LOKI_USERNAME,required"`
-	Token    string `env:"LOKI_AUTH_TOKEN,required"`
 }
 
 func Load() (*Config, error) {

--- a/services/config/config_test.go
+++ b/services/config/config_test.go
@@ -26,9 +26,6 @@ func clearTestEnv() {
 	os.Unsetenv("REDIS_PASSWORD")
 	os.Unsetenv("REDIS_EXPIRATION_TIME")
 
-	os.Unsetenv("LOKI_URL")
-	os.Unsetenv("LOKI_USERNAME")
-	os.Unsetenv("LOKI_AUTH_TOKEN")
 }
 
 func setupTestEnv() {
@@ -51,9 +48,6 @@ func setupTestEnv() {
 	os.Setenv("REDIS_PASSWORD", "test_password")
 	os.Setenv("REDIS_EXPIRATION_TIME", "60s")
 
-	os.Setenv("LOKI_URL", "http://localhost:3100")
-	os.Setenv("LOKI_USERNAME", "test_user")
-	os.Setenv("LOKI_AUTH_TOKEN", "test_token")
 }
 
 func TestLoad(t *testing.T) {
@@ -75,9 +69,6 @@ func TestLoad(t *testing.T) {
 		"REDIS_PORT":             "6379",
 		"REDIS_PASSWORD":         "test_password",
 		"REDIS_EXPIRATION_TIME":  "60s",
-		"LOKI_URL":               "http://localhost:3100",
-		"LOKI_USERNAME":          "test_user",
-		"LOKI_AUTH_TOKEN":        "test_token",
 	}
 
 	for k, v := range env {

--- a/services/logger/logger.go
+++ b/services/logger/logger.go
@@ -1,0 +1,35 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+// SlogAdapter adapts log/slog to the bot.Logger and openai.Logger interfaces.
+type SlogAdapter struct {
+	log *slog.Logger
+}
+
+// New creates a SlogAdapter writing JSON-structured logs to stdout.
+func New() *SlogAdapter {
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	return &SlogAdapter{log: slog.New(handler)}
+}
+
+func (a *SlogAdapter) Info(ctx context.Context, message string, keyValues ...interface{}) error {
+	a.log.InfoContext(ctx, message, keyValues...)
+	return nil
+}
+
+func (a *SlogAdapter) Error(ctx context.Context, message string, keyValues ...interface{}) error {
+	a.log.ErrorContext(ctx, message, keyValues...)
+	return nil
+}
+
+func (a *SlogAdapter) Debug(ctx context.Context, message string, keyValues ...interface{}) error {
+	a.log.DebugContext(ctx, message, keyValues...)
+	return nil
+}

--- a/services/logger/logger.go
+++ b/services/logger/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 )
 
 // SlogAdapter adapts log/slog to the bot.Logger and openai.Logger interfaces.
@@ -12,11 +13,26 @@ type SlogAdapter struct {
 }
 
 // New creates a SlogAdapter writing JSON-structured logs to stdout.
+// The log level is controlled by the LOG_LEVEL env var (DEBUG, INFO, WARN, ERROR).
+// Defaults to INFO.
 func New() *SlogAdapter {
 	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level: parseLevel(os.Getenv("LOG_LEVEL")),
 	})
 	return &SlogAdapter{log: slog.New(handler)}
+}
+
+func parseLevel(s string) slog.Level {
+	switch strings.ToUpper(s) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "WARN":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 func (a *SlogAdapter) Info(ctx context.Context, message string, keyValues ...interface{}) error {

--- a/services/logger/logger_test.go
+++ b/services/logger/logger_test.go
@@ -1,0 +1,23 @@
+package logger_test
+
+import (
+	"context"
+	"testing"
+
+	"telegrambot-assistant/services/logger"
+)
+
+func TestSlogAdapterMethodsReturnNil(t *testing.T) {
+	adapter := logger.New()
+	ctx := context.Background()
+
+	if err := adapter.Info(ctx, "test info", "key", "value"); err != nil {
+		t.Errorf("Info returned non-nil error: %v", err)
+	}
+	if err := adapter.Error(ctx, "test error", "key", "value"); err != nil {
+		t.Errorf("Error returned non-nil error: %v", err)
+	}
+	if err := adapter.Debug(ctx, "test debug", "key", "value"); err != nil {
+		t.Errorf("Debug returned non-nil error: %v", err)
+	}
+}

--- a/services/setup/setup.go
+++ b/services/setup/setup.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"telegrambot-assistant/services/bot"
@@ -57,7 +56,7 @@ func InitBot(cfg config.TelegramConfig, logger bot.Logger) (*bot.Bot, error) {
 		return nil, fmt.Errorf("failed to create Telegram bot: %v", err)
 	}
 
-	log.Printf("TelegramBot: authorized on account %s", telegramBot.Self.UserName)
+	logger.Info(context.Background(), "TelegramBot: authorized on account", "username", telegramBot.Self.UserName)
 
 	// Updated: Use BasicSplitter implementation
 	splitter := bot.NewBasicSplitter(cfg.MessageLimit)

--- a/services/setup/setup.go
+++ b/services/setup/setup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"time"
 
 	"telegrambot-assistant/services/bot"
@@ -14,8 +13,6 @@ import (
 	"telegrambot-assistant/services/storage"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
-	"github.com/mwazovzky/cloudlog/client"
-	"github.com/mwazovzky/cloudlog/logger"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
 	"github.com/redis/go-redis/v9"
@@ -53,25 +50,6 @@ func InitAssistant(cfg config.OpenAIConfig, store responsestore.ResponseStore, l
 	return localai.NewAssistant(&client.Responses, cfg.Model, instructions, store, log, cfg.RequestTimeout)
 }
 
-// LoggerResources holds the logger and async sender for graceful shutdown
-type LoggerResources struct {
-	Logger logger.Logger
-	Sender *logger.AsyncSender
-}
-
-func InitLogger(cfg config.LokiConfig, service string) *LoggerResources {
-	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	lokiClient := client.NewLokiClient(cfg.Url, cfg.Username, cfg.Token, httpClient)
-	sender := logger.NewAsyncSender(lokiClient)
-	log := logger.New(sender, logger.WithJob(service))
-
-	return &LoggerResources{
-		Logger: log,
-		Sender: sender,
-	}
-}
 
 func InitBot(cfg config.TelegramConfig, logger bot.Logger) (*bot.Bot, error) {
 	telegramBot, err := newBotAPI(cfg.ApiToken)

--- a/services/setup/setup_test.go
+++ b/services/setup/setup_test.go
@@ -66,6 +66,7 @@ func TestInitBot(t *testing.T) {
 	bot, err := InitBot(cfg, mockLogger)
 	assert.NoError(t, err)
 	assert.NotNil(t, bot)
+	mockLogger.AssertExpectations(t)
 }
 
 func TestInitResponseStore(t *testing.T) {

--- a/services/setup/setup_test.go
+++ b/services/setup/setup_test.go
@@ -62,6 +62,7 @@ func TestInitBot(t *testing.T) {
 		MessageLimit: 4096,                       // Added MessageLimit
 	}
 	mockLogger := new(MockLogger)
+	mockLogger.On("Info", "TelegramBot: authorized on account", []interface{}{"username", ""}).Return(nil)
 	bot, err := InitBot(cfg, mockLogger)
 	assert.NoError(t, err)
 	assert.NotNil(t, bot)

--- a/services/setup/setup_test.go
+++ b/services/setup/setup_test.go
@@ -86,16 +86,3 @@ func TestInitAssistant(t *testing.T) {
 	assert.NotNil(t, assistant)
 }
 
-func TestInitLogger(t *testing.T) {
-	cfg := config.LokiConfig{
-		Url:      "http://localhost:3100",
-		Username: "test_user",
-		Token:    "test_token",
-	}
-	resources := InitLogger(cfg, "test_service")
-
-	assert.NotNil(t, resources)
-	assert.NotNil(t, resources.Logger)
-	assert.NotNil(t, resources.Sender)
-	resources.Sender.Close()
-}


### PR DESCRIPTION
Replace the custom github.com/mwazovzky/cloudlog package with Go's stdlib log/slog writing JSON to stdout. Add a Promtail sidecar to docker-compose to collect container logs and forward to Grafana Cloud Loki, decoupling log shipping from the application (12-factor).

- Add services/logger: SlogAdapter implementing bot.Logger via slog JSON handler
- Remove LokiConfig from app config; credentials stay in .env for Promtail
- Remove InitLogger/LoggerResources and async sender lifecycle from setup
- Add promtail/config.yml with Docker socket-based service discovery
- Add Promtail service + json-file log rotation to both docker-compose files
- Drop github.com/mwazovzky/cloudlog dependency